### PR TITLE
Add babel-runtime as a production dependency - Closes #33

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"babel-plugin-istanbul": "=4.1.5",
 		"babel-plugin-transform-runtime": "=6.23.0",
 		"babel-preset-env": "=1.6.1",
-		"babel-runtime": "=6.26.0",
 		"chai": "=4.1.2",
 		"chai-as-promised": "=7.1.1",
 		"coveralls": "=3.0.0",
@@ -57,5 +56,8 @@
 		"prettier": "=1.8.2",
 		"sinon": "=4.1.2",
 		"sinon-chai": "=2.14.0"
+	},
+	"dependencies": {
+		"babel-runtime": "=6.26.0"
 	}
 }


### PR DESCRIPTION
Closes #33 