### PR TITLE
Simplify issue template - Closes #46

### DIFF
--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,25 +1,7 @@
-Have you read lisk-template's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/LiskHQ/lisk-template/blob/master/CODE_OF_CONDUCT.md
+### Expected behavior
 
-### Description
+### Actual behavior
 
-[Description of the issue]
+### Steps to reproduce
 
-### Steps to Reproduce
-
-1. [First Step]
-1. [Second Step]
-1. [and so on...]
-
-**Expected behavior:** [What you expect to happen]
-
-**Actual behavior:** [What actually happens]
-
-**Reproduces how often:** [What percentage of the time does it reproduce?]
-
-### Versions
-
-Please provide the version you are working with. Please include the OS and what version of the OS you're running.
-
-### Additional Information
-
-Any additional information, configuration or data that might be necessary to reproduce the issue.
+### Which version(s) does this affect? (Environment, OS, etc...)


### PR DESCRIPTION
Closes #46

This will make it more likely that people use the template. The link to the code of conduct is automatically provided by GitHub so we do not need it in this file.