### PR TITLE
Perform a fresh npm installation prepublish - Closes #54

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"build": "babel src -d dist",
 		"precommit": "lint-staged && npm run lint",
 		"prepush": "npm run lint && npm test",
-		"prepublishOnly": "npm run prepush && npm run build"
+		"prepublishOnly": "rm -r ./node_modules && npm install && npm run prepush && npm run build"
 	},
 	"devDependencies": {
 		"babel-cli": "=6.26.0",


### PR DESCRIPTION
### What was the problem?

We didn't run a fresh npm installation prepublish.

### How did I fix it?

In the npm `prepublishOnly` script I added commands to remove `node_modules` and run `npm install`.

### How to test it?

Run `npm run prepublishOnly`

### Review checklist

- The PR solves #54
- All new code is covered with unit tests
- All new code was formatted with Prettier
- Linting passes
- Tests pass
- Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
