### PR TITLE
Use US English - Closes #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 ## Goals of this repository
 
-1. To gather standards, patterns and workflows which we adopt, in order to provide a central source of truth regarding our "current thinking", which can then be applied to individual Lisk projects as and when appropriate.
+1. To gather standards, patterns and workflows which we adopt, in order to provide a central source of truth regarding our “current thinking”, which can then be applied to individual Lisk projects as and when appropriate.
 1. To serve as a base for new projects.
 
 ## Usage
 
-When starting a new Lisk project, use this repository as a base. With a few small customisations, you will have a skeleton project up and running in a few minutes. The easiest way to bootstrap a new project is using the `bin/bootstrap.sh` script:
+When starting a new Lisk project, use this repository as a base. With a few small customizations, you will have a skeleton project up and running in a few minutes. The easiest way to bootstrap a new project is using the `bin/bootstrap.sh` script:
 
 ```sh
 curl --silent --user my_github_username "https://raw.githubusercontent.com/LiskHQ/lisk-template/master/bin/bootstrap.sh" | bash -ls my-fresh-lisk-project
@@ -36,7 +36,7 @@ If you would rather complete this process on your own, you should follow these s
 1. Clone the repository.
 1. Reinitialise git (by removing the `.git` directory, running `git init` and committing everything into the initial commit).
 1. Find and replace all instances of `lisk-template` with your project name (assuming the name of your project is the same as its GitHub namespace).
-1. Commit these customisation changes.
+1. Commit these customization changes.
 1. Run `npm install`.
 
 More precise steps can be viewed in the `bin/bootstrap.sh` script.
@@ -51,7 +51,7 @@ Installed for your convenience are the following:
 
 1. [Babel][babel] plus various plugins, presets and tools so you can write modern JavaScript without worrying about compatibility.
 1. [Prettier][prettier] for standard code formatting.
-1. [Eslint][eslint] plus various configs and plugins, to enforce additional rules beyond Prettier’s remit.
+1. [ESLint][eslint] plus various configs and plugins, to enforce additional rules beyond Prettier’s remit.
 1. [Husky][husky] and [lint-staged][lint-staged] to help with running checks/builds before/after various git/NPM commands.
 1. [Mocha][mocha], [Chai][chai] and [Sinon][sinon] plus plugins for tests.
 1. [nyc][nyc] and [Coveralls][coveralls] for coverage.
@@ -62,9 +62,9 @@ These can be removed as appropriate, along with the corresponding NPM scripts.
 
 - `start` will run your source code using `babel-node`, which is not performant but does not require transpilation.
 - `format` will format your source and test code using Prettier.
-- `lint` will lint everything relevant with Eslint.
+- `lint` will lint everything relevant with ESLint.
 - `test` will run your tests and instrument your code using nyc. (With the initial setup this results in a failing test: the first step in TDD’s red-green-refactor process!)
-- `test:watch` will watch for changes and reruns your tests.
+- `test:watch` will watch for changes and rerun your tests.
 - `test:watch:min` will do the same but using the `min` reporter (useful if you just want to check if your changes break a test).
 - `cover` will output a coverage report (differs based on the environment).
 - `build` will transpile your source code using Babel.
@@ -74,16 +74,16 @@ These can be removed as appropriate, along with the corresponding NPM scripts.
 
 ## Documentation for contributors
 
-Several files are especially relevant for contributors:
+Several files especially relevant for contributors can be found in the `docs` directory:
 - `CODE_OF_CONDUCT.md` which should probably be left as it is.
-- `CONTRIBUTING.md` which will benefit from project-specific customisation.
-- `ISSUE_TEMPLATE.md` which may need to be adapted to your project.
-- `LICENSE` which should be left alone unless your project is being released under a different licence. In this case the `license` field of the `package.json` file should be updated as well.
+- `CONTRIBUTING.md` which will benefit from project-specific customization.
+- `ISSUE_TEMPLATE.md` and `PULL_REQUEST_TEMPLATE.md` which may need to be adapted to your project.
+- Additionally, in the root of the project is the `LICENSE` file, which should be left alone unless your project is being released under a different license. In this case the `license` field of the `package.json` file should be updated as well.
 
 ## Project structure
 
 - Source code should go in `src`, test code should go in `test`.
-- File names should be `underscore_separated` for best cross-file system compatibility. (I.e. not in camel case etc.)
+- File and directory names should be `underscore_separated` for best cross-file system compatibility. (I.e. not in camel case etc.)
 - nyc output goes into `.nyc_output`, and built files are put into a `dist` directory which is created when needed.
 - Files you do not want to commit can be placed in `.idea` or `tmp` (you will need to create these directories yourself).
 
@@ -95,6 +95,7 @@ If this approach does not suit your project the structure can be replaced as nec
 
 - Combining Babel, nyc and Mocha.
 - Adding Chai’s `expect` as a global, and initialising plugins.
+- Adding `Given`, `When` and `Then` from [mocha-bdd][mocha-bdd] as globals.
 - Adding `sinon` and a sinon `sandbox` as globals, and resetting the sandbox after each test in a global hook (it is recommended to use the sandbox wherever possible to avoid manual resets).
 
 ## Continuous integration
@@ -112,6 +113,7 @@ The `.snyk` file configures Snyk.
 - `.editorconfig` can be used in combination with plugins for a wide range of editors/IDEs to ensure consistency of certain key syntax details.
 - `.npmignore` ensures that as little as possible is included when published to NPM. This may require adjustment.
 - If the project is for a client, or otherwise will not be used as a library in other projects, consider replacing `babel-plugin-transform-runtime` and `babel-runtime` with `babel-polyfill` (see the [details section of the Babel Polyfill documentation](babel-polyfill-details)).
+- The official language for all Lisk projects is US English (although we may also support translations into other languages on a per-project basis).
 
 ## Contributors
 
@@ -139,6 +141,7 @@ You should have received a copy of the [GNU General Public License][license] alo
 [license]: https://github.com/LiskHQ/lisk-template/tree/master/LICENSE
 [lint-staged]: https://github.com/okonet/lint-staged
 [mocha]: http://mochajs.org/
+[mocha-bdd]: https://github.com/LiskHQ/mocha-bdd
 [nvm]: https://github.com/creationix/nvm
 [nyc]: https://istanbul.js.org/
 [prettier]: https://prettier.io/

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -11,17 +11,17 @@ fi
 git clone git@github.com:LiskHQ/lisk-template.git "$projectname"
 cd "$projectname"
 
-# Reinitialise git
+# Reinitialize git
 rm -rf .git
 git init
 git add .
-git commit -m 'Initial commit' -m 'Initialised from lisk-template: https://github.com/LiskHQ/lisk-template'
+git commit -m 'Initial commit' -m 'Initialized from lisk-template: https://github.com/LiskHQ/lisk-template'
 
-# Customise project using provided project name
+# Customize project using provided project name
 git grep -l lisk-template | xargs sed -i '' "s/lisk-template/$projectname/g"
 rm bin/bootstrap.sh
 git add .
-git commit -m "Customise lisk-template as $projectname"
+git commit -m "Customize lisk-template as $projectname"
 
 # Install npm dependencies
 test $(command -v nvm) && nvm use 6.12.2

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -26,7 +26,7 @@ Examples of unacceptable behavior by participants include:
   advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+* Publishing others’ private information, such as a physical or electronic
   address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
@@ -63,7 +63,7 @@ Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+members of the project’s leadership.
 
 ## Attribution
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to lisk-template, which ar
 
 1. [Code of Conduct](#code-of-conduct)
 
-1. [Help! I don't want to read this whole thing, I just have one question. :mag_right:](#help!-i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+1. [Help! I don’t want to read this whole thing, I just have one question. :mag_right:](#help!-i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
 
 1. [How Can I Contribute?](#how-can-i-contribute)
 	1. [Reporting Bugs](#reporting-bugs)
@@ -28,7 +28,7 @@ This project and everyone participating in it is governed by the [lisk-template 
 Every repository within LiskHQ comes with a LICENSE file. Please read it carefully before commiting your code to one of the repositories.
 
 
-## Help! I don't want to read this whole thing, I just have a question. :mag_right:
+## Help! I don’t want to read this whole thing, I just have a question. :mag_right:
 
 Lisk is an open-source decentralized project, there are many ways and platforms to get help. These are some of them:
 
@@ -50,14 +50,15 @@ We will do our best to keep `master` in good shape, with tests passing at all ti
 
 ### Pull Requests
 
-In case you've never submitted a pull request (PR) via GitHub before, please read [this short tutorial](https://help.github.com/articles/creating-a-pull-request). If you've submitted a PR before, there should be nothing surprising about our procedures for Lisk.
+In case you’ve never submitted a pull request (PR) via GitHub before, please read [this short tutorial](https://help.github.com/articles/creating-a-pull-request). If you’ve submitted a PR before, there should be nothing surprising about our procedures for Lisk.
 
 *Before* submitting a pull request, please make sure the following is done:
 
 1. Fork the repo.
 1. If you are creating a pull request that addresses a specific issue, take a look at the projects that issue is a part of (in the right-hand sidebar). Most issues will be a part of a project for a specific version, such as "Version 0.3.0". If this is the case, create your branch from the relevant version branch, e.g. `0.3.0`, and submit your pull request against that branch as a base. Otherwise, create your branch from `master`.
-1. Add tests to the code you have contributed! All new code must come with complete test coverage. See [here](test/README.md) for a guide to the testing approach we’re using.
+1. Add tests to the code you have contributed! All new code must come with complete test coverage.
 1. End all files with a newline. In general, your code should conform to the rules listed in the `.editorconfig` file. There are plugins for most editors/IDEs to do this for you automatically. Update the README for the changes that adhere to your new code.
+1. Format your code using [Prettier](https://prettier.io/). This should be done for you automatically when you commit files, but can be performed manually with `npm run format`.
 1. Ensure the test and linting suite passes (`npm run prepush` runs both). Follow the [JavaScript](https://github.com/airbnb/javascript) styleguide from Airbnb with the [lisk extension](https://github.com/LiskHQ/eslint-config-lisk-base).
 1. Submit a pull request via GitHub. Include issue numbers in the PR title, at the end with: ```Description - Closes #IssueNumber```.
 1. Check that Jenkins CI tests pass (pull request turns green).
@@ -67,9 +68,9 @@ First time contributors will need to wait for a trusted team member to start Jen
 
 This section guides you through submitting a bug report for lisk-template. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
-Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don’t need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
 
-> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you’re experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
 #### Before Submitting A Bug Report
 
@@ -79,33 +80,33 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](https://github.com/LiskHQ) your bug is related to, create an issue on that repository and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you’ve determined [which repository](https://github.com/LiskHQ) your bug is related to, create an issue on that repository and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
 * **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible. When listing steps, **don't just say what you did, but explain how you did it**. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
-* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the exact steps which reproduce the problem** in as many details as possible. When listing steps, **don’t just say what you did, but explain how you did it**. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you’re providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why.**
 * **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
+* **If the problem wasn’t triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
 * **Did the problem start happening recently** (e.g. after updating to a new version of lisk-template, Lisk or any other repository) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of lisk-template?** What's the most recent version in which the problem doesn't happen? You can download older versions of lisk-template from [the releases page](https://github.com/LiskHQ/lisk-template/releases).
+* If the problem started happening recently, **can you reproduce the problem in an older version of lisk-template?** What’s the most recent version in which the problem doesn’t happen? You can download older versions of lisk-template from [the releases page](https://github.com/LiskHQ/lisk-template/releases).
 * **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 ### Suggesting Enhancements
 
 This section guides you through submitting an enhancement suggestion for lisk-template, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
- When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
+ When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you’re requesting existed.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](https://github.com/LiskHQ) your enhancement suggestion is related to, create an issue on that repository and provide the following information:
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you’ve determined [which repository](https://github.com/LiskHQ) your enhancement suggestion is related to, create an issue on that repository and provide the following information:
 
 * **Use a clear and descriptive title** for the issue to identify the suggestion.
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
@@ -113,8 +114,8 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
 * **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of lisk-template which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
 * **Explain why this enhancement would be useful** to most Lisk and lisk-template users.
-* **Specify which version of Lisk and lisk-template you're using.**
-* **Specify the name and version of the OS you're using.**
+* **Specify which version of Lisk and lisk-template you’re using.**
+* **Specify the name and version of the OS you’re using.**
 
 ## Styleguides
 
@@ -143,7 +144,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 
 ### JavaScript Styleguide
 
-On lisk-template we are using [ESLint](https://eslint.org/).
-Our JavaScript style expands [Airbnb's](https://github.com/airbnb/javascript) style. You can get more details here: https://github.com/LiskHQ/eslint-config-lisk-base
+On lisk-template we are using [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/).
+Our ESLint style expands [Airbnb’s](https://github.com/airbnb/javascript) style settings and expresses some opinions not covered by Prettier’s formatting concerns. You can get more details here: https://github.com/LiskHQ/eslint-config-lisk-base
 
-These contribution guidelines were inspired by and are based on Atom's contribution guidelines. They were modified for the purposes of this repository. https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c) 2011-2017 GitHub Inc. (MIT)
+These contribution guidelines were inspired by and are based on Atom’s contribution guidelines. They were modified for the purposes of this repository. https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c) 2011-2017 GitHub Inc. (MIT)


### PR DESCRIPTION
### What was the problem?

We used UK English in places.

### How did I fix it?

I replaced such instances with US English. I also replaced straight quotes with apostrophes or curly quotes where appropriate. A few gaps in documentation have been filled along the way.

### Review checklist

- The PR solves #56 
- Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- Documentation has been added/updated
