### PR TITLE
Add likely optional components to README - Closes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ the following:
 * The official language for all Lisk projects is US English (although we may
 	also support translations into other languages on a per-project basis).
 
+## Applying these standards
+
+All of these standards should be applied with the specific project in mind.
+There might be good reasons to delay the application of some standard, or to
+avoid it completely. In particular, the following are very likely to vary from
+project to project:
+
+* The Babel plugins `babel-plugin-transform-runtime` and `babel-runtime` (where
+	`babel-polyfill` might make more sense)
+* Use of Babel at all
+* The `mocha-bdd` dependency and the testing structure
+* The `npm start` script
+* The `npm run build` script
+
 ## Contributors
 
 https://github.com/LiskHQ/lisk-template/graphs/contributors


### PR DESCRIPTION
### What was the problem?

We didn't highlight components which were relatively likely not to apply to some projects

### How did I fix it?

I added a section to the README

### How to test it?

Read the README

### Review checklist

* The PR solves #43 
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
