### PR TITLE
Start packages at version 0.0.0 - Closes #80

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -19,6 +19,8 @@ git commit -m 'Initial commit' -m 'Initialized from lisk-template: https://githu
 
 # Customize project using provided project name
 git grep -l lisk-template | xargs sed -i '' "s/lisk-template/$projectname/g"
+sed -i '.bak' $'s/\t"version": .*/\t"version": "0.0.0",/' package.json
+rm package.json.bak
 rm bin/bootstrap.sh
 git add .
 git commit -m "Customize lisk-template as $projectname"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lisk-template",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"description": "Template repository for Lisk projects",
 	"author":
 		"Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",


### PR DESCRIPTION
### What was the problem?

`package.json` was starting at 0.1.0, which wasn't the most convenient for use in combination with `npm version` at release time.

### How did I fix it?

Reset to `0.0.0` in `package.json` and added a line to `bootstrap.sh` to replace the version in case we bump it for `lisk-template` itself.

### How to test it?

Run the bootstrap script.

### Review checklist

* The PR solves #80 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
