### PR TITLE
Add babel-register to mocha.opts - Closes #97

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"babel-plugin-istanbul": "=4.1.5",
 		"babel-plugin-transform-runtime": "=6.23.0",
 		"babel-preset-env": "=1.6.1",
+		"babel-register": "=6.26.0",
 		"chai": "=4.1.2",
 		"chai-as-promised": "=7.1.1",
 		"coveralls": "=3.0.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+--require babel-register
 --require ./test/setup.js
 --reporter spec
 --recursive


### PR DESCRIPTION
### What was the problem?

We weren't requiring `babel-register` for tests.

### How did I fix it?

Added `babel-register` as a dependency and required it for tests.

### How to test it?

`npm t`

### Review checklist

* The PR solves #97 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
