### PR TITLE
Remove redundant = prefix for exact package versions - Closes #90

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-save-prefix = "="
+save-exact = true

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"url": "https://github.com/LiskHQ/lisk-template/issues"
 	},
 	"engines": {
-		"node": "=6.14.1",
-		"npm": "=3.10.10"
+		"node": "6.14.1",
+		"npm": "3.10.10"
 	},
 	"main": "dist/index.js",
 	"scripts": {
@@ -40,29 +40,29 @@
 			"rm -r ./node_modules && npm install && npm run prepush && npm run build"
 	},
 	"dependencies": {
-		"babel-runtime": "=6.26.0"
+		"babel-runtime": "6.26.0"
 	},
 	"devDependencies": {
-		"babel-cli": "=6.26.0",
-		"babel-plugin-istanbul": "=4.1.5",
-		"babel-plugin-transform-runtime": "=6.23.0",
-		"babel-preset-env": "=1.6.1",
-		"babel-register": "=6.26.0",
-		"chai": "=4.1.2",
-		"chai-as-promised": "=7.1.1",
-		"coveralls": "=3.0.0",
-		"eslint": "=4.16.0",
-		"eslint-config-airbnb-base": "=12.1.0",
-		"eslint-config-lisk-base": "=1.0.0",
-		"eslint-plugin-import": "=2.8.0",
-		"eslint-plugin-mocha": "=4.11.0",
-		"husky": "=0.14.3",
-		"lint-staged": "=5.0.0",
-		"mocha": "=4.0.1",
-		"mocha-bdd": "=0.1.2",
-		"nyc": "=11.3.0",
-		"prettier": "=1.8.2",
-		"sinon": "=4.1.2",
-		"sinon-chai": "=2.14.0"
+		"babel-cli": "6.26.0",
+		"babel-plugin-istanbul": "4.1.5",
+		"babel-plugin-transform-runtime": "6.23.0",
+		"babel-preset-env": "1.6.1",
+		"babel-register": "6.26.0",
+		"chai": "4.1.2",
+		"chai-as-promised": "7.1.1",
+		"coveralls": "3.0.0",
+		"eslint": "4.16.0",
+		"eslint-config-airbnb-base": "12.1.0",
+		"eslint-config-lisk-base": "1.0.0",
+		"eslint-plugin-import": "2.8.0",
+		"eslint-plugin-mocha": "4.11.0",
+		"husky": "0.14.3",
+		"lint-staged": "5.0.0",
+		"mocha": "4.0.1",
+		"mocha-bdd": "0.1.2",
+		"nyc": "11.3.0",
+		"prettier": "1.8.2",
+		"sinon": "4.1.2",
+		"sinon-chai": "2.14.0"
 	}
 }


### PR DESCRIPTION
### What was the problem?

We used an `=` prefix for specifying exact dependency versions, but it's not necessary and it's not documented by npm.

### How did I fix it?

Removed the prefixes and changed our `.npmrc` to use `save-exact = true`.

### How to test it?

`npm install` or install new packages.

### Review checklist

* The PR solves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
