### PR TITLE
Add .prettierignore file - Closes #84

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+package.json
+
+.nyc_output/
+coverage/
+dist/
+node_modules/
+
+# BUG: See https://github.com/prettier/prettier/issues/3223
+docs/CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -1,68 +1,67 @@
 {
-	"name": "lisk-template",
-	"version": "0.0.0",
-	"description": "Template repository for Lisk projects",
-	"author":
-		"Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
-	"license": "GPL-3.0",
-	"keywords": ["lisk", "blockchain"],
-	"homepage": "https://github.com/LiskHQ/lisk-template#readme",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/LiskHQ/lisk-template.git"
-	},
-	"bugs": {
-		"url": "https://github.com/LiskHQ/lisk-template/issues"
-	},
-	"engines": {
-		"node": "6.14.1",
-		"npm": "3.10.10"
-	},
-	"main": "dist/index.js",
-	"scripts": {
-		"start": "babel-node src/index.js",
-		"format":
-			"prettier --write \"**/*.{js,json,md}\"",
-		"lint": "eslint .",
-		"lint:fix": "npm run lint -- --fix",
-		"test": "NODE_ENV=test nyc mocha",
-		"test:watch": "npm test -- --watch",
-		"test:watch:min": "npm run test:watch -- --reporter=min",
-		"cover":
-			"if [ -z $JENKINS_HOME ]; then npm run cover:local; else npm run cover:ci; fi",
-		"cover:base": "NODE_ENV=test nyc report",
-		"cover:local": "npm run cover:base -- --reporter=html --reporter=text",
-		"cover:ci": "npm run cover:base -- --reporter=text-lcov | coveralls -v",
-		"build": "babel src -d dist",
-		"precommit": "lint-staged && npm run lint",
-		"prepush": "npm run lint && npm test",
-		"prepublishOnly":
-			"rm -r ./node_modules && npm install && npm run prepush && npm run build"
-	},
-	"dependencies": {
-		"babel-runtime": "6.26.0"
-	},
-	"devDependencies": {
-		"babel-cli": "6.26.0",
-		"babel-plugin-istanbul": "4.1.5",
-		"babel-plugin-transform-runtime": "6.23.0",
-		"babel-preset-env": "1.6.1",
-		"babel-register": "6.26.0",
-		"chai": "4.1.2",
-		"chai-as-promised": "7.1.1",
-		"coveralls": "3.0.0",
-		"eslint": "4.16.0",
-		"eslint-config-airbnb-base": "12.1.0",
-		"eslint-config-lisk-base": "1.0.0",
-		"eslint-plugin-import": "2.8.0",
-		"eslint-plugin-mocha": "4.11.0",
-		"husky": "0.14.3",
-		"lint-staged": "5.0.0",
-		"mocha": "4.0.1",
-		"mocha-bdd": "0.1.2",
-		"nyc": "11.3.0",
-		"prettier": "1.8.2",
-		"sinon": "4.1.2",
-		"sinon-chai": "2.14.0"
-	}
+  "name": "lisk-template",
+  "version": "0.0.0",
+  "description": "Template repository for Lisk projects",
+  "author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+  "license": "GPL-3.0",
+  "keywords": [
+    "lisk",
+    "blockchain"
+  ],
+  "homepage": "https://github.com/LiskHQ/lisk-template#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LiskHQ/lisk-template.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LiskHQ/lisk-template/issues"
+  },
+  "engines": {
+    "node": "6.14.1",
+    "npm": "3.10.10"
+  },
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "babel-node src/index.js",
+    "format": "prettier --write \"**/*.{js,json,md}\"",
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "NODE_ENV=test nyc mocha",
+    "test:watch": "npm test -- --watch",
+    "test:watch:min": "npm run test:watch -- --reporter=min",
+    "cover": "if [ -z $JENKINS_HOME ]; then npm run cover:local; else npm run cover:ci; fi",
+    "cover:base": "NODE_ENV=test nyc report",
+    "cover:local": "npm run cover:base -- --reporter=html --reporter=text",
+    "cover:ci": "npm run cover:base -- --reporter=text-lcov | coveralls -v",
+    "build": "babel src -d dist",
+    "precommit": "lint-staged && npm run lint",
+    "prepush": "npm run lint && npm test",
+    "prepublishOnly": "rm -r ./node_modules && npm install && npm run prepush && npm run build"
+  },
+  "dependencies": {
+    "babel-runtime": "6.26.0"
+  },
+  "devDependencies": {
+    "babel-cli": "6.26.0",
+    "babel-plugin-istanbul": "4.1.5",
+    "babel-plugin-transform-runtime": "6.23.0",
+    "babel-preset-env": "1.6.1",
+    "babel-register": "6.26.0",
+    "chai": "4.1.2",
+    "chai-as-promised": "7.1.1",
+    "coveralls": "3.0.0",
+    "eslint": "4.16.0",
+    "eslint-config-airbnb-base": "12.1.0",
+    "eslint-config-lisk-base": "1.0.0",
+    "eslint-plugin-import": "2.8.0",
+    "eslint-plugin-mocha": "4.11.0",
+    "husky": "0.14.3",
+    "lint-staged": "5.0.0",
+    "mocha": "4.0.1",
+    "mocha-bdd": "0.1.2",
+    "nyc": "11.3.0",
+    "prettier": "1.8.2",
+    "sinon": "4.1.2",
+    "sinon-chai": "2.14.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"scripts": {
 		"start": "babel-node src/index.js",
 		"format":
-			"prettier --write \"./*.{js,json,md}\" \"{docs,src,test}{,/**}/*.{js,json,md}\"",
+			"prettier --write \"**/*.{js,json,md}\"",
 		"lint": "eslint .",
 		"lint:fix": "npm run lint -- --fix",
 		"test": "NODE_ENV=test nyc mocha",


### PR DESCRIPTION
### What was the problem?

We had to whitelist files to format and it wasn't easy to exclude files which didn't work well with prettier.

### How did I fix it?

Added a .prettierignore file to blacklist files/directories.

### How to test it?

`npm run format`.

### Review checklist

* The PR solves #84 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
