### PR TITLE
Only lint staged js files precommit - Closes #83

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-	"*.{js,json,md}": ["prettier --write", "git add"]
+	"*.js": ["eslint", "prettier --write", "git add"],
+	"*.{json,md}": ["prettier --write", "git add"]
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cover:local": "npm run cover:base -- --reporter=html --reporter=text",
     "cover:ci": "npm run cover:base -- --reporter=text-lcov | coveralls -v",
     "build": "babel src -d dist",
-    "precommit": "lint-staged && npm run lint",
+    "precommit": "lint-staged",
     "prepush": "npm run lint && npm test",
     "prepublishOnly": "rm -r ./node_modules && npm install && npm run prepush && npm run build"
   },


### PR DESCRIPTION
### What was the problem?

We linted all files precommit, instead of only the staged ones.

### How did I fix it?

Updated package.json and the lint-staged settings.

### How to test it?

Stage some lint-passing js files, and make some lint-failing edits without staging them. Then try to commit (you should be able to).

### Review checklist

* The PR solves #83 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
